### PR TITLE
Adding support for amp-ad content node

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -243,7 +243,8 @@ i-amp-sizer {
 }
 
 .-amp-layout-size-defined > [placeholder],
-.-amp-layout-size-defined > [fallback] {
+.-amp-layout-size-defined > [fallback],
+.-amp-layout-size-defined > [content] {
   position: absolute !important;
   top: 0 !important;
   left: 0 !important;

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -46,6 +46,11 @@ export const AdDisplayState = {
    * ad server.
    */
   LOADED_NO_CONTENT: 3,
+
+  /**
+   * The ad has been laid out, and ad content has been provided statically
+   */
+  LOADED_STATIC_CONTENT: 4,
 };
 
 export class AmpAdUIHandler {
@@ -91,6 +96,9 @@ export class AmpAdUIHandler {
       case AdDisplayState.NOT_LAID_OUT:
         this.displayUnlayoutUI_();
         break;
+      case AdDisplayState.LOADED_STATIC_CONTENT:
+        this.displayStaticContentUI_();
+        break;
       default:
         dev().error(TAG, 'state is not supported');
     }
@@ -126,6 +134,7 @@ export class AmpAdUIHandler {
           // If already unlaid out, do not replace current placeholder then.
           return;
         }
+        this.baseInstance_.toggleContent(false);
         this.baseInstance_.togglePlaceholder(false);
         this.baseInstance_.toggleFallback(true);
         this.state = AdDisplayState.LOADED_NO_CONTENT;
@@ -155,6 +164,21 @@ export class AmpAdUIHandler {
       }
       this.baseInstance_.togglePlaceholder(true);
       this.baseInstance_.toggleFallback(false);
+      this.baseInstance_.toggleContent(false);
+    });
+  }
+
+  /**
+   * Apply UI for static ad
+   * Hide fallback and placeholder if exists
+   * @private
+   */
+  displayStaticContentUI_() {
+    this.state = AdDisplayState.LOADED_STATIC_CONTENT;
+    this.baseInstance_.deferMutate(() => {
+      this.baseInstance_.togglePlaceholder(false);
+      this.baseInstance_.toggleFallback(false);
+      this.baseInstance_.toggleContent(true);
     });
   }
 }

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -195,8 +195,12 @@ export class AmpAdXOriginIframeHandler {
       // unlayout already called
       return;
     }
-    this.freeXOriginIframe(this.iframe.name.indexOf('_master') >= 0);
-    this.uiHandler_.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+    if (this.baseInstance_.getContent()) {
+      this.uiHandler_.setDisplayState(AdDisplayState.LOADED_STATIC_CONTENT);
+    } else {
+      this.freeXOriginIframe(this.iframe.name.indexOf('_master') >= 0);
+      this.uiHandler_.setDisplayState(AdDisplayState.LOADED_NO_CONTENT);
+    }
   }
 
   /**

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -580,6 +580,25 @@ export class BaseElement {
   }
 
   /**
+   * Returns an optional content element for this custom element.
+   * @return {?Element}
+   * @public @final
+   */
+  getContent() {
+    return this.element.getContent();
+  }
+
+  /**
+   * Hides or shows the static content, if available. This function must only
+   * be called inside a mutate context.
+   * @param {boolean} state
+   * @public @final
+   */
+  toggleContent(state) {
+    this.element.toggleContent(state);
+  }
+
+  /**
    * Returns an optional overflow element for this custom element.
    * @return {?Element}
    * @public @final

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1312,6 +1312,36 @@ function createBaseCustomElementClass(win) {
     }
 
     /**
+     * Returns an optional content element for this custom element.
+     * @return {?Element}
+     * @package @final @this {!Element}
+     */
+    getContent() {
+      return dom.childElementByAttr(this, 'content');
+    }
+
+    /**
+     * Hides or shows the static content, if available. This function must only
+     * be called inside a mutate context.
+     * @param {boolean} state
+     * @package @final @this {!Element}
+     */
+    toggleContent(state) {
+      assertNotTemplate(this);
+      if (state == true) {
+        const contentElement = this.getContent();
+        if (contentElement) {
+          this.getResources().scheduleLayout(this, contentElement);
+        }
+        // If we have the content, there's never a need for fallback
+        const fallback = this.getFallback();
+        if (fallback) {
+          fallback.classList.add('amp-hidden');
+        }
+      }
+    }
+
+    /**
      * Whether the loading can be shown for this element.
      * @return {boolean}
      * @private @this {!Element}


### PR DESCRIPTION
Experiment in adding support for 'content' nodes to custom elements, which amp-ad can use to render and track native ads.  Addresses my proposal made in this issue: https://github.com/ampproject/amphtml/issues/5721